### PR TITLE
Update .travis.yml to use openjdk8 instead of oracle's.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false # faster builds
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
With this pull request, openjdk8 should become used by travis, instead of oracle's.