### PR TITLE
Issue-#106: Improve exception information on time out.

### DIFF
--- a/src/main/java/com/github/dakusui/actionunit/actions/TimeOut.java
+++ b/src/main/java/com/github/dakusui/actionunit/actions/TimeOut.java
@@ -36,7 +36,7 @@ public interface TimeOut extends Action {
 
     public Action in(long duration, TimeUnit timeUnit) {
       checkArgument(duration > 0,
-          "Timeout duration must be positive  but %d was given",
+              "Timeout duration must be positive but %d was given",
           duration
       );
       requireNonNull(timeUnit);

--- a/src/main/java/com/github/dakusui/actionunit/utils/InternalUtils.java
+++ b/src/main/java/com/github/dakusui/actionunit/utils/InternalUtils.java
@@ -15,115 +15,115 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public enum InternalUtils {
-    ;
-    public static final Method OBJECT_TO_STRING_METHOD = objectToStringMethod();
+  ;
+  public static final Method OBJECT_TO_STRING_METHOD = objectToStringMethod();
 
-    public static void sleep(long duration, TimeUnit timeUnit) {
-        try {
-            checkNotNull(timeUnit).sleep(duration);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw wrap(e);
-        }
+  public static void sleep(long duration, TimeUnit timeUnit) {
+    try {
+      checkNotNull(timeUnit).sleep(duration);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw wrap(e);
     }
+  }
 
-    public static <T> T runWithTimeout(Callable<T> callable, Supplier<String> description, Supplier<String> timeoutDescription, long timeout, TimeUnit timeUnit) {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final Future<T> future = executor.submit(callable);
-        executor.shutdown(); // This does not cancel the already-scheduled task.
-        try {
-            Thread.interrupted();
-            return future.get(timeout, timeUnit);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw wrap(e);
-        } catch (TimeoutException e) {
-            future.cancel(true);
-            throw new ActionTimeOutException(
-                    String.format("Action: <%s>; %s with message: <%s>", description.get(), timeoutDescription.get(), e.getMessage()),
-                    e);
-        } catch (ExecutionException e) {
-            //unwrap the root cause
-            Throwable cause = e.getCause();
-            if (cause instanceof Error) {
-                throw (Error) cause;
-            }
-            ////
-            // It's safe to directly cast to RuntimeException, because a Callable can only
-            // throw an Error or a RuntimeException.
-            throw (RuntimeException) cause;
-        } finally {
-            executor.shutdownNow();
-        }
+  public static <T> T runWithTimeout(Callable<T> callable, Supplier<String> description, Supplier<String> timeoutDescription, long timeout, TimeUnit timeUnit) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final Future<T> future = executor.submit(callable);
+    executor.shutdown(); // This does not cancel the already-scheduled task.
+    try {
+      Thread.interrupted();
+      return future.get(timeout, timeUnit);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw wrap(e);
+    } catch (TimeoutException e) {
+      future.cancel(true);
+      throw new ActionTimeOutException(
+          String.format("Action: <%s>; %s with message: <%s>", description.get(), timeoutDescription.get(), e.getMessage()),
+          e);
+    } catch (ExecutionException e) {
+      //unwrap the root cause
+      Throwable cause = e.getCause();
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      ////
+      // It's safe to directly cast to RuntimeException, because a Callable can only
+      // throw an Error or a RuntimeException.
+      throw (RuntimeException) cause;
+    } finally {
+      executor.shutdownNow();
     }
+  }
 
-    public static String indent(int level, int indentWidth) {
-        StringBuilder b = new StringBuilder();
-        for (int i = 0; i < level; i++)
-            b.append(spaces(indentWidth));
-        return b.toString();
+  public static String indent(int level, int indentWidth) {
+    StringBuilder b = new StringBuilder();
+    for (int i = 0; i < level; i++)
+      b.append(spaces(indentWidth));
+    return b.toString();
+  }
+
+  public static String formatNumberOfTimes(int i) {
+    if (i == 1)
+      return "once";
+    if (i == 2)
+      return "twice";
+    return String.format("%s times", i);
+  }
+
+
+  public static String formatDuration(long durationInNanos) {
+    TimeUnit timeUnit = chooseTimeUnit(durationInNanos);
+    return format("%d [%s]", timeUnit.convert(durationInNanos, TimeUnit.NANOSECONDS), timeUnit.toString().toLowerCase());
+  }
+
+  private static TimeUnit chooseTimeUnit(long intervalInNanos) {
+    // TimeUnit.values() returns elements of TimeUnit in declared order
+    // And they are declared in ascending order.
+    for (TimeUnit timeUnit : TimeUnit.values()) {
+      if (1000 > timeUnit.convert(intervalInNanos, TimeUnit.NANOSECONDS)) {
+        return timeUnit;
+      }
     }
+    return TimeUnit.DAYS;
+  }
 
-    public static String formatNumberOfTimes(int i) {
-        if (i == 1)
-            return "once";
-        if (i == 2)
-            return "twice";
-        return String.format("%s times", i);
+  public static String spaces(int numSpaces) {
+    StringBuilder ret = new StringBuilder();
+    for (int i = 0; i < numSpaces; i++) {
+      ret.append(" ");
     }
+    return ret.toString();
+  }
 
+  public static String summary(String s) {
+    return requireNonNull(s).length() > 40
+        ? s.substring(0, 40) + "..."
+        : s;
+  }
 
-    public static String formatDuration(long durationInNanos) {
-        TimeUnit timeUnit = chooseTimeUnit(durationInNanos);
-        return format("%d [%s]", timeUnit.convert(durationInNanos, TimeUnit.NANOSECONDS), timeUnit.toString().toLowerCase());
+  public static String objectToStringIfOverridden(Object o, Supplier<String> formatter) {
+    requireNonNull(formatter);
+    try {
+      return !Objects.equals(o.getClass().getMethod("toString"), OBJECT_TO_STRING_METHOD) ?
+          o.toString() :
+          formatter.get();
+    } catch (NoSuchMethodException e) {
+      return formatter.get();
     }
+  }
 
-    private static TimeUnit chooseTimeUnit(long intervalInNanos) {
-        // TimeUnit.values() returns elements of TimeUnit in declared order
-        // And they are declared in ascending order.
-        for (TimeUnit timeUnit : TimeUnit.values()) {
-            if (1000 > timeUnit.convert(intervalInNanos, TimeUnit.NANOSECONDS)) {
-                return timeUnit;
-            }
-        }
-        return TimeUnit.DAYS;
+  private static Method objectToStringMethod() {
+    try {
+      return Object.class.getMethod("toString");
+    } catch (NoSuchMethodException e) {
+      throw wrap(e);
     }
+  }
 
-    public static String spaces(int numSpaces) {
-        StringBuilder ret = new StringBuilder();
-        for (int i = 0; i < numSpaces; i++) {
-            ret.append(" ");
-        }
-        return ret.toString();
-    }
-
-    public static String summary(String s) {
-        return requireNonNull(s).length() > 40
-                ? s.substring(0, 40) + "..."
-                : s;
-    }
-
-    public static String objectToStringIfOverridden(Object o, Supplier<String> formatter) {
-        requireNonNull(formatter);
-        try {
-            return !Objects.equals(o.getClass().getMethod("toString"), OBJECT_TO_STRING_METHOD) ?
-                    o.toString() :
-                    formatter.get();
-        } catch (NoSuchMethodException e) {
-            return formatter.get();
-        }
-    }
-
-    private static Method objectToStringMethod() {
-        try {
-            return Object.class.getMethod("toString");
-        } catch (NoSuchMethodException e) {
-            throw wrap(e);
-        }
-    }
-
-    public static <T, R> Function<T, R> memoize(Function<T, R> function) {
-        Map<T, R> memo = new ConcurrentHashMap<>();
-        return t -> memo.computeIfAbsent(t, function);
-    }
+  public static <T, R> Function<T, R> memoize(Function<T, R> function) {
+    Map<T, R> memo = new ConcurrentHashMap<>();
+    return t -> memo.computeIfAbsent(t, function);
+  }
 }

--- a/src/main/java/com/github/dakusui/actionunit/utils/InternalUtils.java
+++ b/src/main/java/com/github/dakusui/actionunit/utils/InternalUtils.java
@@ -15,115 +15,115 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public enum InternalUtils {
-  ;
-  public static final Method OBJECT_TO_STRING_METHOD = objectToStringMethod();
+    ;
+    public static final Method OBJECT_TO_STRING_METHOD = objectToStringMethod();
 
-  public static void sleep(long duration, TimeUnit timeUnit) {
-    try {
-      checkNotNull(timeUnit).sleep(duration);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw wrap(e);
+    public static void sleep(long duration, TimeUnit timeUnit) {
+        try {
+            checkNotNull(timeUnit).sleep(duration);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw wrap(e);
+        }
     }
-  }
 
-  public static <T> T runWithTimeout(Callable<T> callable, String timeoutDescription, String description, long timeout, TimeUnit timeUnit) {
-    final ExecutorService executor = Executors.newSingleThreadExecutor();
-    final Future<T> future = executor.submit(callable);
-    executor.shutdown(); // This does not cancel the already-scheduled task.
-    try {
-      Thread.interrupted();
-      return future.get(timeout, timeUnit);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw wrap(e);
-    } catch (TimeoutException e) {
-      future.cancel(true);
-      throw new ActionTimeOutException(
-          String.format("Action: <%s>; %s with message: <%s>", description, timeoutDescription, e.getMessage()),
-          e);
-    } catch (ExecutionException e) {
-      //unwrap the root cause
-      Throwable cause = e.getCause();
-      if (cause instanceof Error) {
-        throw (Error) cause;
-      }
-      ////
-      // It's safe to directly cast to RuntimeException, because a Callable can only
-      // throw an Error or a RuntimeException.
-      throw (RuntimeException) cause;
-    } finally {
-      executor.shutdownNow();
+    public static <T> T runWithTimeout(Callable<T> callable, Supplier<String> description, Supplier<String> timeoutDescription, long timeout, TimeUnit timeUnit) {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Future<T> future = executor.submit(callable);
+        executor.shutdown(); // This does not cancel the already-scheduled task.
+        try {
+            Thread.interrupted();
+            return future.get(timeout, timeUnit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw wrap(e);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new ActionTimeOutException(
+                    String.format("Action: <%s>; %s with message: <%s>", description.get(), timeoutDescription.get(), e.getMessage()),
+                    e);
+        } catch (ExecutionException e) {
+            //unwrap the root cause
+            Throwable cause = e.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            ////
+            // It's safe to directly cast to RuntimeException, because a Callable can only
+            // throw an Error or a RuntimeException.
+            throw (RuntimeException) cause;
+        } finally {
+            executor.shutdownNow();
+        }
     }
-  }
 
-  public static String indent(int level, int indentWidth) {
-    StringBuilder b = new StringBuilder();
-    for (int i = 0; i < level; i++)
-      b.append(spaces(indentWidth));
-    return b.toString();
-  }
-
-  public static String formatNumberOfTimes(int i) {
-    if (i == 1)
-      return "once";
-    if (i == 2)
-      return "twice";
-    return String.format("%s times", i);
-  }
-
-
-  public static String formatDuration(long durationInNanos) {
-    TimeUnit timeUnit = chooseTimeUnit(durationInNanos);
-    return format("%d [%s]", timeUnit.convert(durationInNanos, TimeUnit.NANOSECONDS), timeUnit.toString().toLowerCase());
-  }
-
-  private static TimeUnit chooseTimeUnit(long intervalInNanos) {
-    // TimeUnit.values() returns elements of TimeUnit in declared order
-    // And they are declared in ascending order.
-    for (TimeUnit timeUnit : TimeUnit.values()) {
-      if (1000 > timeUnit.convert(intervalInNanos, TimeUnit.NANOSECONDS)) {
-        return timeUnit;
-      }
+    public static String indent(int level, int indentWidth) {
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < level; i++)
+            b.append(spaces(indentWidth));
+        return b.toString();
     }
-    return TimeUnit.DAYS;
-  }
 
-  public static String spaces(int numSpaces) {
-    StringBuilder ret = new StringBuilder();
-    for (int i = 0; i < numSpaces; i++) {
-      ret.append(" ");
+    public static String formatNumberOfTimes(int i) {
+        if (i == 1)
+            return "once";
+        if (i == 2)
+            return "twice";
+        return String.format("%s times", i);
     }
-    return ret.toString();
-  }
 
-  public static String summary(String s) {
-    return requireNonNull(s).length() > 40
-        ? s.substring(0, 40) + "..."
-        : s;
-  }
 
-  public static String objectToStringIfOverridden(Object o, Supplier<String> formatter) {
-    requireNonNull(formatter);
-    try {
-      return !Objects.equals(o.getClass().getMethod("toString"), OBJECT_TO_STRING_METHOD) ?
-          o.toString() :
-          formatter.get();
-    } catch (NoSuchMethodException e) {
-      return formatter.get();
+    public static String formatDuration(long durationInNanos) {
+        TimeUnit timeUnit = chooseTimeUnit(durationInNanos);
+        return format("%d [%s]", timeUnit.convert(durationInNanos, TimeUnit.NANOSECONDS), timeUnit.toString().toLowerCase());
     }
-  }
 
-  private static Method objectToStringMethod() {
-    try {
-      return Object.class.getMethod("toString");
-    } catch (NoSuchMethodException e) {
-      throw wrap(e);
+    private static TimeUnit chooseTimeUnit(long intervalInNanos) {
+        // TimeUnit.values() returns elements of TimeUnit in declared order
+        // And they are declared in ascending order.
+        for (TimeUnit timeUnit : TimeUnit.values()) {
+            if (1000 > timeUnit.convert(intervalInNanos, TimeUnit.NANOSECONDS)) {
+                return timeUnit;
+            }
+        }
+        return TimeUnit.DAYS;
     }
-  }
 
-  public static <T, R> Function<T, R> memoize(Function<T, R> function) {
-    Map<T, R> memo = new ConcurrentHashMap<>();
-    return t -> memo.computeIfAbsent(t, function);
-  }
+    public static String spaces(int numSpaces) {
+        StringBuilder ret = new StringBuilder();
+        for (int i = 0; i < numSpaces; i++) {
+            ret.append(" ");
+        }
+        return ret.toString();
+    }
+
+    public static String summary(String s) {
+        return requireNonNull(s).length() > 40
+                ? s.substring(0, 40) + "..."
+                : s;
+    }
+
+    public static String objectToStringIfOverridden(Object o, Supplier<String> formatter) {
+        requireNonNull(formatter);
+        try {
+            return !Objects.equals(o.getClass().getMethod("toString"), OBJECT_TO_STRING_METHOD) ?
+                    o.toString() :
+                    formatter.get();
+        } catch (NoSuchMethodException e) {
+            return formatter.get();
+        }
+    }
+
+    private static Method objectToStringMethod() {
+        try {
+            return Object.class.getMethod("toString");
+        } catch (NoSuchMethodException e) {
+            throw wrap(e);
+        }
+    }
+
+    public static <T, R> Function<T, R> memoize(Function<T, R> function) {
+        Map<T, R> memo = new ConcurrentHashMap<>();
+        return t -> memo.computeIfAbsent(t, function);
+    }
 }

--- a/src/test/java/com/github/dakusui/actionunit/ut/actions/TimeoutTest.java
+++ b/src/test/java/com/github/dakusui/actionunit/ut/actions/TimeoutTest.java
@@ -23,165 +23,174 @@ import static java.util.concurrent.TimeUnit.*;
 import static java.util.stream.Collectors.toList;
 
 public class TimeoutTest extends TestUtils.TestBase {
-  @Test(expected = IllegalArgumentException.class)
-  public void givenNegativeDuration$whenCreated$thenExceptionThrown() {
-    timeout(nop()).in(-2, SECONDS);
-  }
-
-  @Test(expected = InterruptedException.class)
-  public void whenInterrupted() throws Throwable {
-    final Thread main = currentThread();
-    Thread interrupter = new Thread(() -> {
-      InternalUtils.sleep(500, MILLISECONDS);
-      main.interrupt();
-    });
-    Action action = timeout(
-        TestUtils.sleep(5, SECONDS)
-    ).in(
-        10, SECONDS
-    );
-    interrupter.start();
-    try {
-      action.accept(createActionPerformer());
-    } catch (ActionException e) {
-      throw e.getCause();
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNegativeDuration$whenCreated$thenExceptionThrown() {
+        timeout(nop()).in(-2, SECONDS);
     }
-  }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void givenNonPositive$whenCreateTimeoutAction$thenIllegalArgument() {
-    timeout(nop()).in(0, TimeUnit.SECONDS);
-  }
-
-  @Test(expected = ActionTimeOutException.class)
-  public void givenParallelActionUnderTimeOut() {
-    Action action = timeout(
-        parallel(
-            sequential(
-                sleepAction(100),
-                print("hello1")
-            ),
-            sequential(
-                sleepAction(10),
-                print("hello2")
-            )
-        )
-    ).in(50, MILLISECONDS);
-
-    try {
-      action.accept(createActionPerformer());
-    } catch (ActionTimeOutException e) {
-      assertThat(
-          out,
-          allOf(
-              asString("get", 0).equalTo("hello2").$(),
-              asInteger("size").equalTo(1).$()
-          )
-      );
-      throw e;
-    }
-  }
-
-  @Test(timeout = 2_000, expected = ActionTimeOutException.class)
-  public void givenNotEndingRetryActionInside$whenTimeoutOutside$thenTimeoutsAppropriately() {
-    Action action = timeout(
-        retry(
-            simple("throw an Exception", c -> {
-              throw new RuntimeException();
-            })
-        ).times(Integer.MAX_VALUE)
-            .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
-    ).in(1, SECONDS);
-    action.accept(createActionPerformer());
-  }
-
-  @Test(timeout = 2_000, expected = ActionTimeOutException.class)
-  public void givenLongerTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenOuterTimeoutUsed() {
-    Action action = timeout(
-        timeout(
-            retry(
-                simple("throw an Exception", c -> {
-                  throw new RuntimeException();
-                })
-            ).times(Integer.MAX_VALUE)
-                .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
-        ).in(60, MINUTES)
-    ).in(1, SECONDS);
-    action.accept(createActionPerformer());
-  }
-
-  @Test(timeout = 2_000, expected = ActionTimeOutException.class)
-  public void givenShorterTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenInnerTimeoutUsed() {
-    Action action = timeout(
-        timeout(
-            retry(
-                simple("throw an Exception", c -> {
-                  throw new RuntimeException();
-                })
-            ).times(Integer.MAX_VALUE)
-                .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
-        ).in(100, MILLISECONDS)
-    ).in(1, MINUTES);
-    action.accept(createActionPerformer());
-  }
-
-  @Test(expected = ActionTimeOutException.class)
-  public void issue92() {
-    List<String> alphabets = new ArrayList<String>() {{
-      this.add("a");
-      this.add("b");
-    }};
-
-    Action action = parallel(alphabets.stream()
-        .map(alphabet -> leaf(c -> {
-          if (alphabet.equals("b")) {
-            try {
-              Thread.sleep(2000);
-            } catch (InterruptedException e) {
-              e.getMessage();
-            }
-          }
-        }))
-        .map(a -> timeout(a).in(1, MILLISECONDS))
-        .map(a -> retry(a)
-            .on(ActionException.class)
-            .withIntervalOf(1, MILLISECONDS)
-            .times(2)
-            .$())
-        .collect(toList()));
-
-    try {
-      ReportingActionPerformer.create().performAndReport(action, Writer.Slf4J.INFO);
-    } catch (ActionTimeOutException e) {
-      System.out.println(e.getMessage());
-      e.printStackTrace();
-      assertThat(
-          e.getMessage(),
-          asString()
-              .containsString("timeout")
-              .containsString("with message:")
-              .$());
-      throw e;
-    }
-  }
-
-  private Action sleepAction(long millis) {
-    return simple(String.format("%d[millis]", millis), new ContextConsumer() {
-      @Override
-      public void accept(Context context) {
+    @Test(expected = InterruptedException.class)
+    public void whenInterrupted() throws Throwable {
+        final Thread main = currentThread();
+        Thread interrupter = new Thread(() -> {
+            InternalUtils.sleep(500, MILLISECONDS);
+            main.interrupt();
+        });
+        Action action = timeout(
+                TestUtils.sleep(5, SECONDS)
+        ).in(
+                10, SECONDS
+        );
+        interrupter.start();
         try {
-          Thread.sleep(millis);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw ActionException.wrap(e);
+            action.accept(createActionPerformer());
+        } catch (ActionException e) {
+            throw e.getCause();
         }
-      }
-    });
-  }
+    }
 
-  private Action print(String message) {
-    return simple(String.format("print:'%s'", message),
-        context -> printf(message)
-    );
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNonPositive$whenCreateTimeoutAction$thenIllegalArgument() {
+        timeout(nop()).in(0, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = ActionTimeOutException.class)
+    public void givenParallelActionUnderTimeOut() {
+        Action action = timeout(
+                parallel(
+                        sequential(
+                                sleepAction(100),
+                                print("hello1")
+                        ),
+                        sequential(
+                                sleepAction(10),
+                                print("hello2")
+                        )
+                )
+        ).in(50, MILLISECONDS);
+
+        try {
+            action.accept(createActionPerformer());
+        } catch (ActionTimeOutException e) {
+            assertThat(
+                    out,
+                    allOf(
+                            asString("get", 0).equalTo("hello2").$(),
+                            asInteger("size").equalTo(1).$()
+                    )
+            );
+            throw e;
+        }
+    }
+
+    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
+    public void givenNotEndingRetryActionInside$whenTimeoutOutside$thenTimeoutsAppropriately() {
+        try {
+            Action action = timeout(
+                    retry(simple("throw an Exception", c -> {
+                        throw new RuntimeException("RETRYING");
+                    })).times(Integer.MAX_VALUE)
+                            .on(Exception.class)
+                            .withIntervalOf(10, MILLISECONDS).$())
+                    .in(1, SECONDS);
+            action.accept(createActionPerformer());
+        } catch (ActionTimeOutException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
+    public void givenLongerTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenOuterTimeoutUsed() {
+        try {
+            Action action = timeout(
+                    timeout(
+                            retry(
+                                    simple("throw an Exception", c -> {
+                                        throw new RuntimeException("RETRYING");
+                                    })
+                            ).times(Integer.MAX_VALUE)
+                                    .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
+                    ).in(60, MINUTES)
+            ).in(1, SECONDS);
+            action.accept(createActionPerformer());
+        } catch (ActionTimeOutException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
+    public void givenShorterTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenInnerTimeoutUsed() {
+        Action action = timeout(
+                timeout(
+                        retry(
+                                simple("throw an Exception", c -> {
+                                    throw new RuntimeException("RUNTIME_EXCEPTION_THROWN");
+                                })
+                        ).times(Integer.MAX_VALUE)
+                                .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
+                ).in(100, MILLISECONDS)
+        ).in(1, MINUTES);
+        action.accept(createActionPerformer());
+    }
+
+    @Test(expected = ActionTimeOutException.class)
+    public void issue92() {
+        List<String> alphabets = new ArrayList<String>() {{
+            this.add("a");
+            this.add("b");
+        }};
+
+        Action action = parallel(alphabets.stream()
+                .map(alphabet -> leaf(c -> {
+                    if (alphabet.equals("b")) {
+                        try {
+                            Thread.sleep(2000);
+                        } catch (InterruptedException e) {
+                            System.out.println(e.getMessage());
+                        }
+                    }
+                }))
+                .map(a -> timeout(a).in(1, MILLISECONDS))
+                .map(a -> retry(a)
+                        .on(ActionException.class)
+                        .withIntervalOf(1, MILLISECONDS)
+                        .times(2)
+                        .$())
+                .collect(toList()));
+
+        try {
+            ReportingActionPerformer.create().performAndReport(action, Writer.Slf4J.INFO);
+        } catch (ActionTimeOutException e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            assertThat(
+                    e.getMessage(),
+                    asString()
+                            .containsString("timeout")
+                            .containsString("with message:")
+                            .$());
+            throw e;
+        }
+    }
+
+    private Action sleepAction(long millis) {
+        return simple(String.format("%d[millis]", millis), new ContextConsumer() {
+            @Override
+            public void accept(Context context) {
+                try {
+                    Thread.sleep(millis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw ActionException.wrap(e);
+                }
+            }
+        });
+    }
+
+    private Action print(String message) {
+        return simple(String.format("print:'%s'", message),
+                context -> printf(message)
+        );
+    }
 }

--- a/src/test/java/com/github/dakusui/actionunit/ut/actions/TimeoutTest.java
+++ b/src/test/java/com/github/dakusui/actionunit/ut/actions/TimeoutTest.java
@@ -23,174 +23,174 @@ import static java.util.concurrent.TimeUnit.*;
 import static java.util.stream.Collectors.toList;
 
 public class TimeoutTest extends TestUtils.TestBase {
-    @Test(expected = IllegalArgumentException.class)
-    public void givenNegativeDuration$whenCreated$thenExceptionThrown() {
-        timeout(nop()).in(-2, SECONDS);
+  @Test(expected = IllegalArgumentException.class)
+  public void givenNegativeDuration$whenCreated$thenExceptionThrown() {
+    timeout(nop()).in(-2, SECONDS);
+  }
+
+  @Test(expected = InterruptedException.class)
+  public void whenInterrupted() throws Throwable {
+    final Thread main = currentThread();
+    Thread interrupter = new Thread(() -> {
+      InternalUtils.sleep(500, MILLISECONDS);
+      main.interrupt();
+    });
+    Action action = timeout(
+        TestUtils.sleep(5, SECONDS)
+    ).in(
+        10, SECONDS
+    );
+    interrupter.start();
+    try {
+      action.accept(createActionPerformer());
+    } catch (ActionException e) {
+      throw e.getCause();
     }
+  }
 
-    @Test(expected = InterruptedException.class)
-    public void whenInterrupted() throws Throwable {
-        final Thread main = currentThread();
-        Thread interrupter = new Thread(() -> {
-            InternalUtils.sleep(500, MILLISECONDS);
-            main.interrupt();
-        });
-        Action action = timeout(
-                TestUtils.sleep(5, SECONDS)
-        ).in(
-                10, SECONDS
-        );
-        interrupter.start();
-        try {
-            action.accept(createActionPerformer());
-        } catch (ActionException e) {
-            throw e.getCause();
-        }
+  @Test(expected = IllegalArgumentException.class)
+  public void givenNonPositive$whenCreateTimeoutAction$thenIllegalArgument() {
+    timeout(nop()).in(0, TimeUnit.SECONDS);
+  }
+
+  @Test(expected = ActionTimeOutException.class)
+  public void givenParallelActionUnderTimeOut() {
+    Action action = timeout(
+        parallel(
+            sequential(
+                sleepAction(100),
+                print("hello1")
+            ),
+            sequential(
+                sleepAction(10),
+                print("hello2")
+            )
+        )
+    ).in(50, MILLISECONDS);
+
+    try {
+      action.accept(createActionPerformer());
+    } catch (ActionTimeOutException e) {
+      assertThat(
+          out,
+          allOf(
+              asString("get", 0).equalTo("hello2").$(),
+              asInteger("size").equalTo(1).$()
+          )
+      );
+      throw e;
     }
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void givenNonPositive$whenCreateTimeoutAction$thenIllegalArgument() {
-        timeout(nop()).in(0, TimeUnit.SECONDS);
+  @Test(timeout = 2_000, expected = ActionTimeOutException.class)
+  public void givenNotEndingRetryActionInside$whenTimeoutOutside$thenTimeoutsAppropriately() {
+    try {
+      Action action = timeout(
+          retry(simple("throw an Exception", c -> {
+            throw new RuntimeException("RETRYING");
+          })).times(Integer.MAX_VALUE)
+              .on(Exception.class)
+              .withIntervalOf(10, MILLISECONDS).$())
+          .in(1, SECONDS);
+      action.accept(createActionPerformer());
+    } catch (ActionTimeOutException e) {
+      e.printStackTrace();
+      throw e;
     }
+  }
 
-    @Test(expected = ActionTimeOutException.class)
-    public void givenParallelActionUnderTimeOut() {
-        Action action = timeout(
-                parallel(
-                        sequential(
-                                sleepAction(100),
-                                print("hello1")
-                        ),
-                        sequential(
-                                sleepAction(10),
-                                print("hello2")
-                        )
-                )
-        ).in(50, MILLISECONDS);
-
-        try {
-            action.accept(createActionPerformer());
-        } catch (ActionTimeOutException e) {
-            assertThat(
-                    out,
-                    allOf(
-                            asString("get", 0).equalTo("hello2").$(),
-                            asInteger("size").equalTo(1).$()
-                    )
-            );
-            throw e;
-        }
+  @Test(timeout = 2_000, expected = ActionTimeOutException.class)
+  public void givenLongerTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenOuterTimeoutUsed() {
+    try {
+      Action action = timeout(
+          timeout(
+              retry(
+                  simple("throw an Exception", c -> {
+                    throw new RuntimeException("RETRYING");
+                  })
+              ).times(Integer.MAX_VALUE)
+                  .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
+          ).in(60, MINUTES)
+      ).in(1, SECONDS);
+      action.accept(createActionPerformer());
+    } catch (ActionTimeOutException e) {
+      e.printStackTrace();
+      throw e;
     }
+  }
 
-    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
-    public void givenNotEndingRetryActionInside$whenTimeoutOutside$thenTimeoutsAppropriately() {
-        try {
-            Action action = timeout(
-                    retry(simple("throw an Exception", c -> {
-                        throw new RuntimeException("RETRYING");
-                    })).times(Integer.MAX_VALUE)
-                            .on(Exception.class)
-                            .withIntervalOf(10, MILLISECONDS).$())
-                    .in(1, SECONDS);
-            action.accept(createActionPerformer());
-        } catch (ActionTimeOutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
+  @Test(timeout = 2_000, expected = ActionTimeOutException.class)
+  public void givenShorterTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenInnerTimeoutUsed() {
+    Action action = timeout(
+        timeout(
+            retry(
+                simple("throw an Exception", c -> {
+                  throw new RuntimeException("RUNTIME_EXCEPTION_THROWN");
+                })
+            ).times(Integer.MAX_VALUE)
+                .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
+        ).in(100, MILLISECONDS)
+    ).in(1, MINUTES);
+    action.accept(createActionPerformer());
+  }
 
-    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
-    public void givenLongerTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenOuterTimeoutUsed() {
-        try {
-            Action action = timeout(
-                    timeout(
-                            retry(
-                                    simple("throw an Exception", c -> {
-                                        throw new RuntimeException("RETRYING");
-                                    })
-                            ).times(Integer.MAX_VALUE)
-                                    .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
-                    ).in(60, MINUTES)
-            ).in(1, SECONDS);
-            action.accept(createActionPerformer());
-        } catch (ActionTimeOutException e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
+  @Test(expected = ActionTimeOutException.class)
+  public void issue92() {
+    List<String> alphabets = new ArrayList<String>() {{
+      this.add("a");
+      this.add("b");
+    }};
 
-    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
-    public void givenShorterTimeoutActionWhichHoldsNotEndingRetryAction$whenTimeoutOutside$thenInnerTimeoutUsed() {
-        Action action = timeout(
-                timeout(
-                        retry(
-                                simple("throw an Exception", c -> {
-                                    throw new RuntimeException("RUNTIME_EXCEPTION_THROWN");
-                                })
-                        ).times(Integer.MAX_VALUE)
-                                .on(Exception.class).withIntervalOf(10, MILLISECONDS).$()
-                ).in(100, MILLISECONDS)
-        ).in(1, MINUTES);
-        action.accept(createActionPerformer());
-    }
-
-    @Test(expected = ActionTimeOutException.class)
-    public void issue92() {
-        List<String> alphabets = new ArrayList<String>() {{
-            this.add("a");
-            this.add("b");
-        }};
-
-        Action action = parallel(alphabets.stream()
-                .map(alphabet -> leaf(c -> {
-                    if (alphabet.equals("b")) {
-                        try {
-                            Thread.sleep(2000);
-                        } catch (InterruptedException e) {
-                            System.out.println(e.getMessage());
-                        }
-                    }
-                }))
-                .map(a -> timeout(a).in(1, MILLISECONDS))
-                .map(a -> retry(a)
-                        .on(ActionException.class)
-                        .withIntervalOf(1, MILLISECONDS)
-                        .times(2)
-                        .$())
-                .collect(toList()));
-
-        try {
-            ReportingActionPerformer.create().performAndReport(action, Writer.Slf4J.INFO);
-        } catch (ActionTimeOutException e) {
-            System.out.println(e.getMessage());
-            e.printStackTrace();
-            assertThat(
-                    e.getMessage(),
-                    asString()
-                            .containsString("timeout")
-                            .containsString("with message:")
-                            .$());
-            throw e;
-        }
-    }
-
-    private Action sleepAction(long millis) {
-        return simple(String.format("%d[millis]", millis), new ContextConsumer() {
-            @Override
-            public void accept(Context context) {
-                try {
-                    Thread.sleep(millis);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw ActionException.wrap(e);
-                }
+    Action action = parallel(alphabets.stream()
+        .map(alphabet -> leaf(c -> {
+          if (alphabet.equals("b")) {
+            try {
+              Thread.sleep(2000);
+            } catch (InterruptedException e) {
+              System.out.println(e.getMessage());
             }
-        });
-    }
+          }
+        }))
+        .map(a -> timeout(a).in(1, MILLISECONDS))
+        .map(a -> retry(a)
+            .on(ActionException.class)
+            .withIntervalOf(1, MILLISECONDS)
+            .times(2)
+            .$())
+        .collect(toList()));
 
-    private Action print(String message) {
-        return simple(String.format("print:'%s'", message),
-                context -> printf(message)
-        );
+    try {
+      ReportingActionPerformer.create().performAndReport(action, Writer.Slf4J.INFO);
+    } catch (ActionTimeOutException e) {
+      System.out.println(e.getMessage());
+      e.printStackTrace();
+      assertThat(
+          e.getMessage(),
+          asString()
+              .containsString("timeout")
+              .containsString("with message:")
+              .$());
+      throw e;
     }
+  }
+
+  private Action sleepAction(long millis) {
+    return simple(String.format("%d[millis]", millis), new ContextConsumer() {
+      @Override
+      public void accept(Context context) {
+        try {
+          Thread.sleep(millis);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw ActionException.wrap(e);
+        }
+      }
+    });
+  }
+
+  private Action print(String message) {
+    return simple(String.format("print:'%s'", message),
+        context -> printf(message)
+    );
+  }
 }


### PR DESCRIPTION
With this pull request, actionunit will show following stacktrace;

```
com.github.dakusui.actionunit.exceptions.ActionTimeOutException: Action: <timeout in 1 [seconds]>; 
throw an Exception
----
RETRYING
    com.github.dakusui.actionunit.ut.actions.TimeoutTest.lambda$givenNotEndingRetryActionInside$whenTimeoutOutside$thenTimeoutsAppropriately$1(TimeoutTest.java:90)
    com.github.dakusui.actionunit.actions.Leaf$1.lambda$runnable$0(Leaf.java:28)
    com.github.dakusui.actionunit.visitors.ActionPerformer.visit(ActionPerformer.java:27)
    com.github.dakusui.actionunit.actions.Leaf.accept(Leaf.java:20)
    com.github.dakusui.actionunit.visitors.SimpleActionPerformer.callAccept(SimpleActionPerformer.java:18)
    com.github.dakusui.actionunit.visitors.ActionPerformer.visit(ActionPerformer.java:31)
```

for the code below.

```
    @Test(timeout = 2_000, expected = ActionTimeOutException.class)
    public void givenNotEndingRetryActionInside$whenTimeoutOutside$thenTimeoutsAppropriately() {
        try {
            Action action = timeout(
                    retry(simple("throw an Exception", c -> {
                        throw new RuntimeException("RETRYING");
                    })).times(Integer.MAX_VALUE)
                            .on(Exception.class)
                            .withIntervalOf(10, MILLISECONDS).$())
                    .in(1, SECONDS);
            action.accept(createActionPerformer());
        } catch (ActionTimeOutException e) {
            e.printStackTrace();
            throw e;
        }
    }

```